### PR TITLE
Add Windows x64 binary

### DIFF
--- a/.github/workflows/release-from-nightlies.yml
+++ b/.github/workflows/release-from-nightlies.yml
@@ -70,6 +70,18 @@ jobs:
           cat package.json
           npm publish --access=public
 
+      - name: Publish win32_x64 subpackage
+        run: |
+          cd subpackages/win32_x64/
+          wget https://github.com/roc-lang/roc/releases/download/nightly/roc_nightly-windows_x86_64-latest.tar.gz
+          tar xzf *.tar.gz
+          rm *.tar.gz
+          mv roc_nightly*/roc .
+          sed -i "s/\(\"version\": \"[^\"]*\)\"/\1$NIGHTLY_VERSION\"/" package.json
+          wc -c roc
+          cat package.json
+          npm publish --access=public
+
       # Now that all the subpackages have been published, publish this one.
       - name: Publish roc-npm
         run: |

--- a/subpackages/win32_x64/README.md
+++ b/subpackages/win32_x64/README.md
@@ -1,0 +1,3 @@
+# Roc installer asset
+
+This is the Windows 64-bit X86 binary for [Roc](https://roc-lang.org).

--- a/subpackages/win32_x64/package.json
+++ b/subpackages/win32_x64/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@roc-installer-assets/win32_x64",
+  "version": "0.0.3",
+  "description": "The Windows 64-bit X86 binary for Roc.",
+  "repository": "https://github.com/vendrinc/roc-npm",
+  "author": "Richard Feldman",
+  "license": "UPL-1.0",
+  "preferUnplugged": true,
+  "files": ["roc"],
+  "os": ["win32"],
+  "cpu": ["x64"]
+}


### PR DESCRIPTION
**DRAFT** - Do not merge until https://github.com/roc-lang/roc/issues/5834 is done, because otherwise there won't be a Windows nightly to download, and new releases of this entire npm package will fail!